### PR TITLE
Add startup and other scripts

### DIFF
--- a/install-dependencies
+++ b/install-dependencies
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+cd
+mkdir -p foreign_src/
+cd foreign_src
+brew install wget
+wget -O - http://static.druid.io/artifacts/releases/druid-0.9.2-bin.tar.gz | tar -xzf -
+brew install zookeeper
+cd /usr/local/etc/zookeeper
+cp zoo_sample.cfg zoo.cfg
+
+brew install Caskroom/cask/virtualbox
+brew install Caskroom/cask/vagrant

--- a/login-server
+++ b/login-server
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+vagrant ssh -- -R 2181:localhost:2181
+

--- a/meta/install.sh
+++ b/meta/install.sh
@@ -7,3 +7,44 @@ sudo apt-get install default-jre -y
 
 # The generate-example-metrics script is written in Python
 sudo apt-get install python -y
+
+# Making Tranquility start on boot requires Upstart.
+
+sudo apt-get install upstart -y
+
+cat << EOT > /tmp/start-tranquility.sh
+#!/bin/bash
+
+( date
+  set -x
+  cd /app/to-druid/tranquility-distribution-0.8.0
+  pwd
+  ls -l
+  ls -l /app
+  ls -l /app/to-druid
+  bin/tranquility server -configFile ../tranquility-server-conf-from-druid-quickstart.json ) >> /var/log/tranquility.log 2>&1
+EOT
+
+sudo cp /tmp/start-tranquility.sh /usr/local/bin/start-tranquility
+sudo chmod +x /usr/local/bin/start-tranquility
+
+cat << EOT > /tmp/rc.local
+#!/bin/sh -e
+#
+# rc.local
+#
+# This script is executed at the end of each multiuser runlevel.
+# Make sure that the script will "exit 0" on success or any other
+# value on error.
+#
+# In order to enable or disable this script just change the execution
+# bits.
+#
+# By default this script does nothing.
+
+sleep 60
+exec /usr/local/bin/start-tranquility
+EOT
+
+sudo cp /tmp/rc.local /etc
+sudo chmod +x /etc/rc.local

--- a/meta/install.sh
+++ b/meta/install.sh
@@ -8,10 +8,6 @@ sudo apt-get install default-jre -y
 # The generate-example-metrics script is written in Python
 sudo apt-get install python -y
 
-# Making Tranquility start on boot requires Upstart.
-
-sudo apt-get install upstart -y
-
 cat << EOT > /tmp/start-tranquility.sh
 #!/bin/bash
 


### PR DESCRIPTION
It took some effort (stemming from the fact that Vagrant doesn't mount `/app` until after all the init scripts have loaded), but this PR makes Tranquility start when you boot the emulator.
